### PR TITLE
Fix line wrapping within inline code (duplicate of upstream PR 130)

### DIFF
--- a/src/generation/generate.rs
+++ b/src/generation/generate.rs
@@ -433,7 +433,7 @@ fn gen_code_block(code_block: &CodeBlock, context: &mut Context) -> PrintItems {
   }
 }
 
-fn gen_code(code: &Code, _: &mut Context) -> PrintItems {
+fn gen_code(code: &Code, context: &mut Context) -> PrintItems {
   let text = code.code.trim();
   let mut backtick_text = "`";
   let mut separator = "";
@@ -444,7 +444,8 @@ fn gen_code(code: &Code, _: &mut Context) -> PrintItems {
     }
   }
 
-  format!("{0}{1}{2}{1}{0}", backtick_text, separator, text).into()
+  let full_string = format!("{0}{1}{2}{1}{0}", backtick_text, separator, text);
+  gen_str(&full_string, context)
 }
 
 fn gen_text(text: &Text, context: &mut Context) -> PrintItems {

--- a/tests/specs/Code/Code_Inline_TextWrap_Always.txt
+++ b/tests/specs/Code/Code_Inline_TextWrap_Always.txt
@@ -18,3 +18,10 @@ Testing
 
 [expect]
 Testing `this` out.
+
+!! should wrap inline code across lines !!
+Testing `this
+out`.
+
+[expect]
+Testing `this out`.


### PR DESCRIPTION
Lands dprint/dprint-plugin-markdown#130 on this fork so we can use the fix locally while waiting for that to merge.